### PR TITLE
Initial experimental version

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+Copyright (c) 2013, Glue developers
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+ * Neither the name of the Glue project nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
-# gaia-experimental
-Experiments with GAIA data exploration
+# GAIA data visualization in Glue
+
+This is not yet functional, and is intended to be a sandbox for experimentation.
+
+At the moment, this just sets up a dataset with 10^7 points on the sky that
+auto-updates as view limits are changed.
+
+

--- a/glue_gaia/__init__.py
+++ b/glue_gaia/__init__.py
@@ -1,0 +1,6 @@
+def setup():
+
+    from .qt_widget import GAIAScatterWidget
+    from glue.config import qt_client
+
+    qt_client.add(GAIAScatterWidget)

--- a/glue_gaia/data.py
+++ b/glue_gaia/data.py
@@ -1,0 +1,12 @@
+# Fake data for now!
+
+import numpy as np
+
+N = 1e7
+X = np.random.uniform(-180., 180, N)
+Y = np.random.uniform(-90., 90, N)
+
+def get_data_subset(xmin, xmax, ymin, ymax):
+    keep = (X > xmin) & (X < xmax) & (Y > ymin) & (Y < ymax)
+    print("Extracting {0} data points".format(np.sum(keep)))
+    return X[keep], Y[keep]

--- a/glue_gaia/qt_widget.py
+++ b/glue_gaia/qt_widget.py
@@ -1,0 +1,65 @@
+# A scatter widget that automatically updates the data
+
+import numpy as np
+
+from glue.qt.widgets.scatter_widget import ScatterWidget
+from glue.core import Data, Component
+from glue.core.message import ComponentsChangedMessage
+
+from glue.core.callback_property import add_callback
+
+N = 1e7
+X = np.random.uniform(-180., 180, N)
+Y = np.random.uniform(-90., 90, N)
+
+def get_data_subset(xmin, xmax, ymin, ymax):
+    keep = (X > xmin) & (X < xmax) & (Y > ymin) & (Y < ymax)
+    print("Extracting {0} data points".format(np.sum(keep)))
+    return X[keep], Y[keep]
+
+class GAIAScatterWidget(ScatterWidget):
+
+    LABEL = "GAIA explorer"
+
+    def __init__(self, session, parent=None):
+
+        super(GAIAScatterWidget, self).__init__(session, parent=parent)
+
+        x, y = get_data_subset(-1., 1., -1., 1.)
+
+        self.gaia_data = Data(label="GAIA")
+        self.gaia_data.add_component(x, label='x')
+        self.gaia_data.add_component(y, label='y')
+
+        self.session.data_collection.append(self.gaia_data)
+
+        self.add_data(self.gaia_data)
+
+        add_callback(self.client, 'xmin', self.limits_changed)
+        add_callback(self.client, 'xmax', self.limits_changed)
+        add_callback(self.client, 'ymin', self.limits_changed)
+        add_callback(self.client, 'ymax', self.limits_changed)
+
+    def limits_changed(self, *args, **kwargs):
+
+        x, y = get_data_subset(self.client.xmin, self.client.xmax, self.client.ymin, self.client.ymax)
+
+        # Find link between component names and IDs
+        component_ids = {}
+        for component_id in self.gaia_data._components:
+            component_ids[component_id.label] = component_id
+
+        # Remove world and pixel components
+        self.gaia_data._components.pop(component_ids['World 0'])
+        self.gaia_data._components.pop(component_ids['Pixel Axis 0'])
+
+        # Replace data in components
+        xc = Component(x)
+        yc = Component(y)
+        self.gaia_data._components[component_ids['x']] = xc
+        self.gaia_data._components[component_ids['y']] = yc
+        self.gaia_data._shape = xc.shape
+        self.gaia_data._create_pixel_and_world_components()
+
+        self.client.artists[0].force_update()
+

--- a/glue_gaia/qt_widget.py
+++ b/glue_gaia/qt_widget.py
@@ -8,14 +8,8 @@ from glue.core.message import ComponentsChangedMessage
 
 from glue.core.callback_property import add_callback
 
-N = 1e7
-X = np.random.uniform(-180., 180, N)
-Y = np.random.uniform(-90., 90, N)
+from .data import get_data_subset
 
-def get_data_subset(xmin, xmax, ymin, ymax):
-    keep = (X > xmin) & (X < xmax) & (Y > ymin) & (Y < ymax)
-    print("Extracting {0} data points".format(np.sum(keep)))
-    return X[keep], Y[keep]
 
 class GAIAScatterWidget(ScatterWidget):
 
@@ -42,7 +36,8 @@ class GAIAScatterWidget(ScatterWidget):
 
     def limits_changed(self, *args, **kwargs):
 
-        x, y = get_data_subset(self.client.xmin, self.client.xmax, self.client.ymin, self.client.ymax)
+        x, y = get_data_subset(self.client.xmin, self.client.xmax,
+                               self.client.ymin, self.client.ymax)
 
         # Find link between component names and IDs
         component_ids = {}

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+from setuptools import setup, find_packages
+
+entry_points = """
+[glue.plugins]
+gaia_viewer=glue_gaia:setup
+"""
+
+setup(name='glue-gaia',
+      version="0.1.dev0",
+      description = "Experimental GAIA plugin for glue",
+      author='Thomas Robitaille',
+      author_email='thomas.robitaille@gmail.com',
+      url='http://glueviz.org',
+      classifiers=[
+          'Intended Audience :: Science/Research',
+          'Operating System :: OS Independent',
+          'Programming Language :: Python :: 2.6',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3.3',
+          'Programming Language :: Python :: 3.4',
+          'Topic :: Scientific/Engineering :: Visualization',
+          'License :: OSI Approved :: BSD License'
+          ],
+      packages = find_packages(),
+      package_data={'': ['*.ui'], '': ['*.png']},
+      entry_points=entry_points
+    )


### PR DESCRIPTION
This is an experiment to see if we can make a scatter plot viewer that updates the dataset when the view limits are changed (the idea being that this could then be connected to remote resources such as the GAIA catalog). At the moment, 10^7 points are generated at the start, and the dataset is updated on-the-fly as view limits are changed.

Of course, this is applicable beyond the GAIA use case, but I thought we can work on this first and worry after about generalizing.

**Note**: since I don't have much information on the GAIA software, I may have misuderstood and maybe the visualization to select the data is done by another program and all we need is the dynamic dataset part. It seems maybe that's the first thing to work on (a dataset that can change size and causes all clients to update when it is changed).

**What should probably be changed**
- Maybe we don't need a subclass of the viewer as long as we can connect the self.client.xmin etc properties from the outside. However, we then have to add GAIA dataset manually. See next point.
- Maybe instead of creating the GAIA data viewer we should have a way to say 'add new remote data source' and the plugin would add a GAIA entry there.
- The resizing of the dataset is uglyyyyyy. We should maybe have a way to resize a dataset, though it's not clear what the values should be changed to before they are updated. We could consider creating a new sub-class of Data (e.g. DynamicData) for this kind of situation specifically.

**What doesn't work (yet)**
- When the view limits are changed, the dataset is updated, but other viewers don't update.

@ChrisBeaumont - do you have any thoughts on this so far?
